### PR TITLE
v21.4.30 - Improve the api to toggle the visibility of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 _These notes are added from the most recent on the top, to the oldest at the bottom._
 
-Next version: 21.4.30
+Next version: 21.4.31
+
+### 2021-04-26 - v21.4.30
+
+* Aligned the API of all entities to use `set*Visible(boolean)` instead of show/hide methods.
+* Reviewed the scope of all the services; set the core services to `providedIn: root`.
 
 ### 2021-04-25 - v21.4.29
 
 * Merged the three sub-layers of the constellations layer into one layer object.
-* Remove the SupportedLayers class which contained constants only.
+* Removed the SupportedLayers class which contained constants only.
 
 ### 2021-04-23 - v21.4.28
 

--- a/doc/follow-up.md
+++ b/doc/follow-up.md
@@ -2,8 +2,6 @@
 
 _If an idea of this list looks concrete enough and useful for the application, it should be transformed into an issue in the project's issues tracker and removed from this list._
 
-* Show the planets at a specific time, support a "timelapse" animation.
-
 * Add the "Kiddy" theme.
 
 * Make objects selectable in the view, probably with additional text info.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrocadre",
-  "version": "21.4.29",
+  "version": "21.4.30",
   "description": "Astronomy sky charts viewing application, runnable in any modern Web browser",
   "keywords": [
     "astronomy",

--- a/src/app/modules/controls/components/selector-layer/selector-layer.component.spec.ts
+++ b/src/app/modules/controls/components/selector-layer/selector-layer.component.spec.ts
@@ -48,12 +48,12 @@ describe('SelectorLayerComponent', () => {
     describe('get should return', () => {
 
       it('true if the layer is shown', () => {
-        visibilityManager.showLayer(code);
+        visibilityManager.setVisible(code, true);
         expect(component.isShown).toBeTrue();
       });
 
       it('false if the layer is not shown', () => {
-        visibilityManager.hideLayer(code);
+        visibilityManager.setVisible(code, false);
         expect(component.isShown).toBeFalse();
       });
 
@@ -62,14 +62,14 @@ describe('SelectorLayerComponent', () => {
     describe('set should', () => {
 
       it('show the layer if arg is true', () => {
-        visibilityManager.hideLayer(code);
+        visibilityManager.setVisible(code, false);
         expect(visibilityManager.isShown(code)).toBeFalse();
         component.isShown = true;
         expect(visibilityManager.isShown(code)).toBeTrue();
       });
 
       it('hide the layer if arg is false', () => {
-        visibilityManager.showLayer(code);
+        visibilityManager.setVisible(code, true);
         expect(visibilityManager.isShown(code)).toBeTrue();
         component.isShown = false;
         expect(visibilityManager.isShown(code)).toBeFalse();

--- a/src/app/modules/controls/components/selector-layer/selector-layer.component.ts
+++ b/src/app/modules/controls/components/selector-layer/selector-layer.component.ts
@@ -45,11 +45,7 @@ export class SelectorLayerComponent {
   }
 
   public set isShown(show: boolean) {
-    if (show) {
-      this._visibilityManager.showLayer(this._layer.code);
-    } else {
-      this._visibilityManager.hideLayer(this._layer.code);
-    }
+    this._visibilityManager.setVisible(this._layer.code, show);
   }
 
   public get subLayers(): Array<Layer> {

--- a/src/app/modules/controls/services/loader.service.ts
+++ b/src/app/modules/controls/services/loader.service.ts
@@ -125,7 +125,7 @@ export class LoaderService {
       );
     this._layerService.registerLayer(renderable);
     this._searchService.registerSearchables(renderable?.searchables);
-    this._visibilityManager.showLayer(layer?.code);
+    this._visibilityManager.setVisible(layer?.code, true);
   }
 
 }

--- a/src/app/modules/core/components/ui-controls-with-names.ts
+++ b/src/app/modules/core/components/ui-controls-with-names.ts
@@ -1,6 +1,6 @@
+import { Directive } from '@angular/core';
 import { LayerAware } from '#core/models/layers/layer-aware';
 import { TextsVisibilityManagerService } from '#core/services/visibility/texts-visibility-manager.service';
-import { Directive } from '@angular/core';
 
 /**
  * Common class for the UI controls that provide a possibility to
@@ -23,11 +23,7 @@ export class UiControlsWithNames extends LayerAware {
 
   public set namesShown(show: boolean) {
     this._namesShown = show;
-    if (this._namesShown) {
-      this._textsVisibilityManager.showTexts(this.layer.code);
-    } else {
-      this._textsVisibilityManager.hideTexts(this.layer.code);
-    }
+    this._textsVisibilityManager.setTextsVisible(this.layer.code, this._namesShown);
   }
 
 }

--- a/src/app/modules/core/core.module.ts
+++ b/src/app/modules/core/core.module.ts
@@ -1,19 +1,5 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { CameraService } from '#core/services/camera.service';
-import { LayerService } from '#core/services/layer.service';
-import { MouseEventsHandler } from '#core/services/mouse-events-handler';
-import { SceneService } from '#core/services/scene.service';
-import { SearchService } from '#core/services/search.service';
-import { StaticDataService } from '#core/services/static-data.service';
-import { ThemeService } from '#core/services/theme.service';
-import { ViewportService } from '#core/services/viewport.service';
-import { LayersVisibilityManagerService } from '#core/services/visibility/layers-visibility-manager.service';
-import { TextsVisibilityManagerService } from '#core/services/visibility/texts-visibility-manager.service';
-import { PointsFactoryService } from '#core/services/factories/points-factory.service';
-import { AxialCurvesFactoryService } from '#core/services/factories/axial-curves-factory.service';
-import { AggregateLayerFactoryService } from '#core/services/factories/aggregate-layer-factory.service';
-import { VirtualSphereRadiusService } from '#core/services/virtual-sphere-radius.service';
 
 /**
  * Contains the core entities of the application, which provide
@@ -22,22 +8,6 @@ import { VirtualSphereRadiusService } from '#core/services/virtual-sphere-radius
 @NgModule({
   imports: [
     HttpClientModule
-  ],
-  providers: [
-    AggregateLayerFactoryService,
-    AxialCurvesFactoryService,
-    CameraService,
-    LayerService,
-    LayersVisibilityManagerService,
-    MouseEventsHandler,
-    PointsFactoryService,
-    SceneService,
-    SearchService,
-    StaticDataService,
-    TextsVisibilityManagerService,
-    ThemeService,
-    ViewportService,
-    VirtualSphereRadiusService
   ]
 })
 export class CoreModule {

--- a/src/app/modules/core/services/camera.service.ts
+++ b/src/app/modules/core/services/camera.service.ts
@@ -15,7 +15,7 @@ import { VirtualSphereRadiusService } from '#core/services/virtual-sphere-radius
 /**
  * Holds the reference to the camera object and provides methods to change the view.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class CameraService {
 
   /**

--- a/src/app/modules/core/services/factories/aggregate-layer-factory.service.spec.ts
+++ b/src/app/modules/core/services/factories/aggregate-layer-factory.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { Layer } from '#core/models/layers/layer';
+import { AggregateLayerFactoryService } from '#core/services/factories/aggregate-layer-factory.service';
+
+
+describe('AggregateLayerFactoryService', () => {
+
+  let factory: AggregateLayerFactoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AggregateLayerFactoryService]
+    });
+    factory = TestBed.inject(AggregateLayerFactoryService);
+  });
+
+  describe('buildRenderableLayer should return', () => {
+
+    it('undefined if the arg is falsy', () => {
+      expect(factory.buildRenderableLayer(undefined)).toBeUndefined();
+    });
+
+    it('an instance of AggregateLayer if the arg is defined', () => {
+      const model: Layer = {
+        code: 'something',
+        label: 'Something',
+        loadFromUrl: false,
+        objects: []
+      };
+      const layer = factory.buildRenderableLayer(model);
+      expect(layer).toBeDefined();
+      expect(layer.code).toEqual(model.code);
+    });
+
+  });
+
+});

--- a/src/app/modules/core/services/factories/aggregate-layer-factory.service.ts
+++ b/src/app/modules/core/services/factories/aggregate-layer-factory.service.ts
@@ -3,6 +3,7 @@ import { AggregateLayer } from '#core/models/layers/aggregate-layer';
 import { LayerFactory } from '#core/models/layers/layer-factory';
 import { Layer } from '#core/models/layers/layer';
 
+// TODO remove it
 /**
  * Factory object for AggregateLayer instances.
  */

--- a/src/app/modules/core/services/factories/aggregate-layer-factory.service.ts
+++ b/src/app/modules/core/services/factories/aggregate-layer-factory.service.ts
@@ -3,15 +3,18 @@ import { AggregateLayer } from '#core/models/layers/aggregate-layer';
 import { LayerFactory } from '#core/models/layers/layer-factory';
 import { Layer } from '#core/models/layers/layer';
 
-// TODO remove it
 /**
  * Factory object for AggregateLayer instances.
+ *
  */
 @Injectable()
 export class AggregateLayerFactoryService implements LayerFactory {
 
   public buildRenderableLayer(model: Layer): AggregateLayer {
-    return new AggregateLayer(model);
+    if (model) {
+      return new AggregateLayer(model);
+    }
+    return undefined;
   }
 
 }

--- a/src/app/modules/core/services/factories/axial-curves-factory.service.ts
+++ b/src/app/modules/core/services/factories/axial-curves-factory.service.ts
@@ -8,7 +8,7 @@ import { VirtualSphereRadiusService } from '#core/services/virtual-sphere-radius
 /**
  * Factory for the curves situated on the 3D world sphere.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class AxialCurvesFactoryService extends Object3DFactory<LineSegments> {
 
   private readonly _intermediatePointsDensity = 5.0; // the bigger the less dense, but uglier in the view!

--- a/src/app/modules/core/services/factories/points-factory.service.ts
+++ b/src/app/modules/core/services/factories/points-factory.service.ts
@@ -7,7 +7,7 @@ import { VirtualSphereRadiusService } from '#core/services/virtual-sphere-radius
 /**
  * Factory object allowing to transform source coordinates data into 3D points data.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class PointsFactoryService extends Object3DFactory<Points> {
 
   constructor(virtualSphereService: VirtualSphereRadiusService) {

--- a/src/app/modules/core/services/layer.service.ts
+++ b/src/app/modules/core/services/layer.service.ts
@@ -8,7 +8,7 @@ import { ThemeEvent } from '#core/models/event/theme-event';
  * Holds the information of the current layers tree and
  * provides the accessors to the layers.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class LayerService {
 
   private _rootLayer: Layer;

--- a/src/app/modules/core/services/mouse-events-handler.ts
+++ b/src/app/modules/core/services/mouse-events-handler.ts
@@ -5,7 +5,7 @@ import { CameraService } from '#core/services/camera.service';
 /**
  * Provides a method to bind mouse event listeners to a DOM element.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class MouseEventsHandler {
 
   private _mousePressed: boolean;

--- a/src/app/modules/core/services/scene.service.spec.ts
+++ b/src/app/modules/core/services/scene.service.spec.ts
@@ -28,7 +28,7 @@ describe('SceneService', () => {
     service.setViewportRootElement(document.createElement('div'));
     const layer = TestBed.inject(MockedGridLayerFactory).buildRenderableLayer();
     layers.registerLayer(layer);
-    visibilityManager.showLayer(layer.code);
+    visibilityManager.setVisible(layer.code, true);
   });
 
   const getMockedLayer = (): RenderableLayer => (
@@ -62,7 +62,7 @@ describe('SceneService', () => {
     expect(visibilityManager.isShown(code)).toBeTrue();
     expect(service.allTextsCount).toEqual(1);
 
-    visibilityManager.hideLayer(code);
+    visibilityManager.setVisible(code, false);
 
     expect(layer.objects.length).toEqual(2);
     expect(layer.texts.length).toEqual(1);

--- a/src/app/modules/core/services/scene.service.ts
+++ b/src/app/modules/core/services/scene.service.ts
@@ -29,7 +29,7 @@ import { TextsHiddenEvent } from '#core/models/event/texts-hidden-event';
 /**
  * Manages the current scene.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class SceneService {
 
   private readonly _scene: Scene;

--- a/src/app/modules/core/services/search.service.ts
+++ b/src/app/modules/core/services/search.service.ts
@@ -8,7 +8,7 @@ import { SkyCoordinate } from '#core/models/screen/sky-coordinate';
  *
  * The search is be done among the searchable items registered in this service.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class SearchService {
 
   private readonly _starStandardNamePattern = /[A-Z]+\s+[A-Z]+/;

--- a/src/app/modules/core/services/static-data.service.ts
+++ b/src/app/modules/core/services/static-data.service.ts
@@ -9,7 +9,7 @@ import { environment } from '#environments/environment';
 /**
  * Provides methods to access the static data from the back-end.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class StaticDataService {
 
   constructor(private readonly _httpClient: HttpClient) {

--- a/src/app/modules/core/services/theme.service.ts
+++ b/src/app/modules/core/services/theme.service.ts
@@ -10,7 +10,7 @@ import { ThemeChangedEvent } from '#core/models/event/theme-changed-event';
  * Holds the values of the themes that are available in the application,
  * and the value of the currently selected theme.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class ThemeService {
 
   private readonly _events: BehaviorSubject<ThemeEvent<any>>;

--- a/src/app/modules/core/services/viewport.service.ts
+++ b/src/app/modules/core/services/viewport.service.ts
@@ -10,7 +10,7 @@ import { ViewportViewChangeEvent } from '#core/models/event/viewport-view-change
  * Holds the value corresponding to the current size of the viewport and provides
  * methods related with the viewport.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class ViewportService {
 
   private readonly _events: BehaviorSubject<ViewportEvent<any>>;

--- a/src/app/modules/core/services/virtual-sphere-radius.service.ts
+++ b/src/app/modules/core/services/virtual-sphere-radius.service.ts
@@ -7,7 +7,7 @@ import { LayerService } from '#core/services/layer.service';
  * the virtual sphere created in the viewport.
  *
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class VirtualSphereRadiusService {
 
   private readonly _maxRadius: number;

--- a/src/app/modules/core/services/visibility/layers-visibility-manager.service.spec.ts
+++ b/src/app/modules/core/services/visibility/layers-visibility-manager.service.spec.ts
@@ -88,7 +88,7 @@ describe('LayersVisibilityManagerService', () => {
 
     it('true if the layer is expected to be shown', () => {
       loadMockedGridLayer();
-      manager.showLayer(skyGrid);
+      manager.setVisible(skyGrid, true);
       expect(manager.isShown(skyGrid)).toBeTrue();
     });
 
@@ -124,46 +124,37 @@ describe('LayersVisibilityManagerService', () => {
       it('when a layer is shown', (done: DoneFn) => {
         loadMockedGridLayer();
         assertEventPropagated(LayerShownEvent.KEY, done);
-        manager.showLayer(skyGrid);
+        manager.setVisible(skyGrid, true);
       });
 
       it('when a layer is hidden', (done: DoneFn) => {
         loadMockedGridLayer();
         assertEventPropagated(LayerHiddenEvent.KEY, done);
-        manager.hideLayer(skyGrid);
+        manager.setVisible(skyGrid, false);
       });
 
     });
 
   });
 
-  describe('showLayer should', () => {
+  describe('setVisible should', () => {
 
     it('have no effect if the arg is falsy', () => {
-      manager.showLayer(undefined);
+      manager.setVisible(undefined, true);
       expect(manager.isShown(undefined)).toBeFalse();
     });
 
-    it('show the layer and its sub-layers', () => {
+    it('show the layer and its sub-layers if the 2nd arg is true', () => {
       loadHierarchicalLayers();
 
-      manager.showLayer(stars);
+      manager.setVisible(stars, true);
       assertLayersShown([stars, starsMag2]);
     });
 
-  });
-
-  describe('hideLayer should', () => {
-
-    it('have no effect if the arg is falsy', () => {
-      manager.hideLayer(undefined);
-      expect(manager.isShown(undefined)).toBeFalse();
-    });
-
-    it('hide the layer and its sub-layers', () => {
+    it('hide the layer and its sub-layers if the 2nd arg is false', () => {
       loadHierarchicalLayers();
 
-      manager.hideLayer(stars);
+      manager.setVisible(stars, false);
       assertLayersHidden([stars, starsMag2]);
     });
 

--- a/src/app/modules/core/services/visibility/layers-visibility-manager.service.spec.ts
+++ b/src/app/modules/core/services/visibility/layers-visibility-manager.service.spec.ts
@@ -39,6 +39,7 @@ describe('LayersVisibilityManagerService', () => {
     TestBed.configureTestingModule({
       imports: [CoreModule],
       providers: [
+        AggregateLayerFactoryService,
         MockedGridLayerFactory
       ]
     });

--- a/src/app/modules/core/services/visibility/layers-visibility-manager.service.ts
+++ b/src/app/modules/core/services/visibility/layers-visibility-manager.service.ts
@@ -9,7 +9,7 @@ import { LayerHiddenEvent } from '#core/models/event/layer-hidden-event';
 /**
  * Provides methods to manage the visibility of layers of objects.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class LayersVisibilityManagerService {
 
   private readonly _events: BehaviorSubject<LayerEvent<any>>;

--- a/src/app/modules/core/services/visibility/texts-visibility-manager.service.spec.ts
+++ b/src/app/modules/core/services/visibility/texts-visibility-manager.service.spec.ts
@@ -57,12 +57,12 @@ describe('TextsVisibilityManagerService', () => {
 
       it('when the texts of a layer are shown', (done: DoneFn) => {
         assertEventPropagated(TextsShownEvent.KEY, done);
-        manager.showTexts(code);
+        manager.setTextsVisible(code, true);
       });
 
       it('when the texts of a layer are hidden', (done: DoneFn) => {
         assertEventPropagated(TextsHiddenEvent.KEY, done);
-        manager.hideTexts(code);
+        manager.setTextsVisible(code, false);
       });
 
     });

--- a/src/app/modules/core/services/visibility/texts-visibility-manager.service.ts
+++ b/src/app/modules/core/services/visibility/texts-visibility-manager.service.ts
@@ -26,34 +26,20 @@ export class TextsVisibilityManagerService {
   }
 
   /**
-   * Shows all the text objects of the specified layer.
+   * Shows or hides the texts of the specified layer.
    *
-   * @param code the code of the layer to show the texts for.
+   * @param code the code of the layer.
+   * @param visible true to show, false to hide the texts.
    */
-  public showTexts(code: string): void {
+  public setTextsVisible(code: string, visible: boolean): void {
     const layer = this._layerService.getRenderableLayer(code);
     if (!layer) {
       return;
     }
-    this._events.next(new TextsShownEvent(layer));
+    const event = visible ? new TextsShownEvent(layer) : new TextsHiddenEvent(layer);
+    this._events.next(event);
     layer.subLayers?.forEach(
-      (subLayer: Layer) => this.showTexts(subLayer.code)
-    );
-  }
-
-  /**
-   * Hides all the text objects of the specified layer.
-   *
-   * @param code the code of the layer to hide the texts for.
-   */
-  public hideTexts(code: string): void {
-    const layer = this._layerService.getRenderableLayer(code);
-    if (!layer) {
-      return;
-    }
-    this._events.next(new TextsHiddenEvent(layer));
-    layer.subLayers?.forEach(
-      (subLayer: Layer) => this.hideTexts(subLayer.code)
+      (subLayer: Layer) => this.setTextsVisible(subLayer.code, visible)
     );
   }
 

--- a/src/app/modules/core/services/visibility/texts-visibility-manager.service.ts
+++ b/src/app/modules/core/services/visibility/texts-visibility-manager.service.ts
@@ -9,7 +9,7 @@ import { TextsHiddenEvent } from '#core/models/event/texts-hidden-event';
 /**
  * Provides methods to manage the visibility of text objects.
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class TextsVisibilityManagerService {
 
   private readonly _events: BehaviorSubject<LayerEvent<any>>;

--- a/src/app/modules/layer-constellations/components/layer-constellations-controls/layer-constellations-controls.component.spec.ts
+++ b/src/app/modules/layer-constellations/components/layer-constellations-controls/layer-constellations-controls.component.spec.ts
@@ -46,7 +46,7 @@ describe('LayerConstellationsControlsComponent', () => {
     textsVisibilityManager = TestBed.inject(TextsVisibilityManagerService);
     const renderable = TestBed.inject(ConstellationsProvidersService).getRenderableLayer(layer);
     TestBed.inject(LayerService).registerLayer(renderable);
-    TestBed.inject(LayersVisibilityManagerService).showLayer(layer.code);
+    TestBed.inject(LayersVisibilityManagerService).setVisible(layer.code, true);
     component = TestBed.createComponent(LayerConstellationsControlsComponent).componentInstance;
     component.layer = renderable;
   });
@@ -58,21 +58,17 @@ describe('LayerConstellationsControlsComponent', () => {
     });
 
     it('trigger the showing of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = true;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(1);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
     it('trigger the hiding of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = false;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(0);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
   });
@@ -84,19 +80,19 @@ describe('LayerConstellationsControlsComponent', () => {
     });
 
     it('trigger the showing of the boundaries', () => {
-      spyOn(visibilityManager, 'showBoundaries');
+      spyOn(visibilityManager, 'setBoundariesVisible');
 
       component.boundariesShown = true;
-      expect(visibilityManager.showBoundaries).toHaveBeenCalledTimes(1);
-      expect(visibilityManager.showBoundaries).toHaveBeenCalledWith(true);
+      expect(visibilityManager.setBoundariesVisible).toHaveBeenCalledTimes(1);
+      expect(visibilityManager.setBoundariesVisible).toHaveBeenCalledWith(true);
     });
 
     it('trigger the hiding of the boundaries', () => {
-      spyOn(visibilityManager, 'showBoundaries');
+      spyOn(visibilityManager, 'setBoundariesVisible');
 
       component.boundariesShown = false;
-      expect(visibilityManager.showBoundaries).toHaveBeenCalledTimes(1);
-      expect(visibilityManager.showBoundaries).toHaveBeenCalledWith(false);
+      expect(visibilityManager.setBoundariesVisible).toHaveBeenCalledTimes(1);
+      expect(visibilityManager.setBoundariesVisible).toHaveBeenCalledWith(false);
     });
 
   });
@@ -108,19 +104,19 @@ describe('LayerConstellationsControlsComponent', () => {
     });
 
     it('trigger the showing of the lines', () => {
-      spyOn(visibilityManager, 'showLines');
+      spyOn(visibilityManager, 'setLinesVisible');
 
       component.linesShown = true;
-      expect(visibilityManager.showLines).toHaveBeenCalledTimes(1);
-      expect(visibilityManager.showLines).toHaveBeenCalledWith(true);
+      expect(visibilityManager.setLinesVisible).toHaveBeenCalledTimes(1);
+      expect(visibilityManager.setLinesVisible).toHaveBeenCalledWith(true);
     });
 
     it('trigger the hiding of the lines', () => {
-      spyOn(visibilityManager, 'showLines');
+      spyOn(visibilityManager, 'setLinesVisible');
 
       component.linesShown = false;
-      expect(visibilityManager.showLines).toHaveBeenCalledTimes(1);
-      expect(visibilityManager.showLines).toHaveBeenCalledWith(false);
+      expect(visibilityManager.setLinesVisible).toHaveBeenCalledTimes(1);
+      expect(visibilityManager.setLinesVisible).toHaveBeenCalledWith(false);
     });
 
   });

--- a/src/app/modules/layer-constellations/components/layer-constellations-controls/layer-constellations-controls.component.ts
+++ b/src/app/modules/layer-constellations/components/layer-constellations-controls/layer-constellations-controls.component.ts
@@ -31,7 +31,7 @@ export class LayerConstellationsControlsComponent extends UiControlsWithNames {
 
   public set boundariesShown(show: boolean) {
     this._boundariesShown = show;
-    this._visibilityManager.showBoundaries(show);
+    this._visibilityManager.setBoundariesVisible(show);
   }
 
   public get linesShown(): boolean {
@@ -40,7 +40,7 @@ export class LayerConstellationsControlsComponent extends UiControlsWithNames {
 
   public set linesShown(show: boolean) {
     this._linesShown = show;
-    this._visibilityManager.showLines(show);
+    this._visibilityManager.setLinesVisible(show);
   }
 
 }

--- a/src/app/modules/layer-constellations/models/constellations.spec.ts
+++ b/src/app/modules/layer-constellations/models/constellations.spec.ts
@@ -115,17 +115,17 @@ describe('Constellations', () => {
       it('have no effect if the boundaries are already shown', () => {
         expect(layer.objects.length).toEqual(2);
 
-        layer.showBoundaries(true);
+        layer.setBoundariesVisible(true);
         expect(layer.objects.length).toEqual(2);
       });
 
       it('show the boundaries if they were hidden', () => {
         const boundaries = layer.objects[0];
-        layer.showBoundaries(false);
+        layer.setBoundariesVisible(false);
         expect(layer.objects.length).toEqual(1);
         expect(layer.objects[0]).not.toEqual(boundaries);
 
-        layer.showBoundaries(true);
+        layer.setBoundariesVisible(true);
         expect(layer.objects.length).toEqual(2);
         expect(layer.objects[1]).toEqual(boundaries);
       });
@@ -135,10 +135,10 @@ describe('Constellations', () => {
     describe('if the arg is false', () => {
 
       it('have no effect if the boundaries are already hidden', () => {
-        layer.showBoundaries(false);
+        layer.setBoundariesVisible(false);
         expect(layer.objects.length).toEqual(1);
 
-        layer.showBoundaries(false);
+        layer.setBoundariesVisible(false);
         expect(layer.objects.length).toEqual(1);
       });
 
@@ -147,7 +147,7 @@ describe('Constellations', () => {
         expect(layer.objects.length).toEqual(2);
         expect(layer.objects[0]).toEqual(boundaries);
 
-        layer.showBoundaries(false);
+        layer.setBoundariesVisible(false);
         expect(layer.objects.length).toEqual(1);
         expect(layer.objects[0]).not.toEqual(boundaries);
       });
@@ -163,17 +163,17 @@ describe('Constellations', () => {
       it('have no effect if the lines are already shown', () => {
         expect(layer.objects.length).toEqual(2);
 
-        layer.showLines(true);
+        layer.setLinesVisible(true);
         expect(layer.objects.length).toEqual(2);
       });
 
       it('show the lines if they were hidden', () => {
         const lines = layer.objects[1];
-        layer.showLines(false);
+        layer.setLinesVisible(false);
         expect(layer.objects.length).toEqual(1);
         expect(layer.objects[0]).not.toEqual(lines);
 
-        layer.showLines(true);
+        layer.setLinesVisible(true);
         expect(layer.objects.length).toEqual(2);
         expect(layer.objects[1]).toEqual(lines);
       });
@@ -183,10 +183,10 @@ describe('Constellations', () => {
     describe('if the arg is false', () => {
 
       it('have no effect if the lines are already hidden', () => {
-        layer.showLines(false);
+        layer.setLinesVisible(false);
         expect(layer.objects.length).toEqual(1);
 
-        layer.showLines(false);
+        layer.setLinesVisible(false);
         expect(layer.objects.length).toEqual(1);
       });
 
@@ -195,7 +195,7 @@ describe('Constellations', () => {
         expect(layer.objects.length).toEqual(2);
         expect(layer.objects[1]).toEqual(lines);
 
-        layer.showLines(false);
+        layer.setLinesVisible(false);
         expect(layer.objects.length).toEqual(1);
         expect(layer.objects[0]).not.toEqual(lines);
       });

--- a/src/app/modules/layer-constellations/models/constellations.ts
+++ b/src/app/modules/layer-constellations/models/constellations.ts
@@ -52,22 +52,22 @@ export class Constellations extends RenderableLayer {
     );
   }
 
-  public showBoundaries(show: boolean): void {
-    this.showObject(show, this._boundaries);
+  public setBoundariesVisible(visible: boolean): void {
+    this.setObjectVisible(visible, this._boundaries);
   }
 
-  public showLines(show: boolean): void {
-    this.showObject(show, this._lines);
+  public setLinesVisible(visible: boolean): void {
+    this.setObjectVisible(visible, this._lines);
   }
 
-  private showObject(show: boolean, object: Object3D): void {
+  private setObjectVisible(visible: boolean, object: Object3D): void {
     const indexObject = this._objects.findIndex(
       (obj: Object3D) => obj === object
     );
-    if (show && indexObject === -1) {
+    if (visible && indexObject === -1) {
       this._objects.push(object);
     }
-    if (!show && indexObject > -1) {
+    if (!visible && indexObject > -1) {
       this._objects.splice(indexObject, 1);
     }
   }

--- a/src/app/modules/layer-constellations/services/visibility/constellations-visibility-manager.service.spec.ts
+++ b/src/app/modules/layer-constellations/services/visibility/constellations-visibility-manager.service.spec.ts
@@ -52,84 +52,72 @@ describe('ConstellationsVisibilityManagerService', () => {
     const provider = TestBed.inject(ConstellationsProvidersService);
     const layer = provider.getRenderableLayer(model);
     layerService.registerLayer(layer);
-    layersManager.showLayer(constellations);
+    layersManager.setVisible(constellations, true);
     return layer;
   };
 
-  describe('showBoundaries should', () => {
+  describe('setBoundariesVisible should', () => {
 
     it('have no effect if the layer does not exist', () => {
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
+      spyOn(layersManager, 'setVisible');
 
-      manager.showBoundaries(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(0);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(0);
+      manager.setBoundariesVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(0);
     });
 
     it('if the arg is true, trigger the showing of the boundaries', () => {
       const layer = loadConstellationsLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'showBoundaries');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setBoundariesVisible');
 
-      manager.showBoundaries(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showBoundaries).toHaveBeenCalledTimes(1);
-      expect(layer.showBoundaries).toHaveBeenCalledWith(true);
+      manager.setBoundariesVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setBoundariesVisible).toHaveBeenCalledTimes(1);
+      expect(layer.setBoundariesVisible).toHaveBeenCalledWith(true);
     });
 
     it('if the arg is false, trigger the hiding of the boundaries', () => {
       const layer = loadConstellationsLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'showBoundaries');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setBoundariesVisible');
 
-      manager.showBoundaries(false);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showBoundaries).toHaveBeenCalledTimes(1);
-      expect(layer.showBoundaries).toHaveBeenCalledWith(false);
+      manager.setBoundariesVisible(false);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setBoundariesVisible).toHaveBeenCalledTimes(1);
+      expect(layer.setBoundariesVisible).toHaveBeenCalledWith(false);
     });
 
   });
 
-  describe('showLines should', () => {
+  describe('setLinesVisible should', () => {
 
     it('have no effect if the layer does not exist', () => {
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
+      spyOn(layersManager, 'setVisible');
 
-      manager.showLines(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(0);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(0);
+      manager.setLinesVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(0);
     });
 
     it('if the arg is true, trigger the showing of the lines', () => {
       const layer = loadConstellationsLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'showLines');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setLinesVisible');
 
-      manager.showLines(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showLines).toHaveBeenCalledTimes(1);
-      expect(layer.showLines).toHaveBeenCalledWith(true);
+      manager.setLinesVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setLinesVisible).toHaveBeenCalledTimes(1);
+      expect(layer.setLinesVisible).toHaveBeenCalledWith(true);
     });
 
     it('if the arg is false, trigger the hiding of the lines', () => {
       const layer = loadConstellationsLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'showLines');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setLinesVisible');
 
-      manager.showLines(false);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showLines).toHaveBeenCalledTimes(1);
-      expect(layer.showLines).toHaveBeenCalledWith(false);
+      manager.setLinesVisible(false);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setLinesVisible).toHaveBeenCalledTimes(1);
+      expect(layer.setLinesVisible).toHaveBeenCalledWith(false);
     });
 
   });

--- a/src/app/modules/layer-constellations/services/visibility/constellations-visibility-manager.service.ts
+++ b/src/app/modules/layer-constellations/services/visibility/constellations-visibility-manager.service.ts
@@ -20,12 +20,12 @@ export class ConstellationsVisibilityManagerService {
     this._layerCode = Constellations.CODE;
   }
 
-  public showBoundaries(show: boolean): void {
-    this.showObjects(show, (layer: Constellations, isShown: boolean) => layer.showBoundaries(isShown));
+  public setBoundariesVisible(vesible: boolean): void {
+    this.showObjects(vesible, (layer: Constellations, isShown: boolean) => layer.setBoundariesVisible(isShown));
   }
 
-  public showLines(show: boolean): void {
-    this.showObjects(show, (layer: Constellations, isShown: boolean) => layer.showLines(isShown));
+  public setLinesVisible(visible: boolean): void {
+    this.showObjects(visible, (layer: Constellations, isShown: boolean) => layer.setLinesVisible(isShown));
   }
 
   private showObjects(
@@ -36,9 +36,9 @@ export class ConstellationsVisibilityManagerService {
     if (!layer) {
       return;
     }
-    this._layersVisibilityManager.hideLayer(this._layerCode);
+    this._layersVisibilityManager.setVisible(this._layerCode, false);
     showFunction(layer, show);
-    this._layersVisibilityManager.showLayer(this._layerCode);
+    this._layersVisibilityManager.setVisible(this._layerCode, true);
   }
 
   private getConstellationsLayer(): Constellations {

--- a/src/app/modules/layer-messier/components/selector-messier-names/selector-messier-names.component.spec.ts
+++ b/src/app/modules/layer-messier/components/selector-messier-names/selector-messier-names.component.spec.ts
@@ -37,21 +37,17 @@ describe('SelectorMessierNamesComponent', () => {
     });
 
     it('trigger the showing of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = true;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(1);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
     it('trigger the hiding of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = false;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(0);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
   });

--- a/src/app/modules/layer-solar-system/components/selector-solar-system-objects/selector-solar-system-objects.component.spec.ts
+++ b/src/app/modules/layer-solar-system/components/selector-solar-system-objects/selector-solar-system-objects.component.spec.ts
@@ -40,21 +40,17 @@ describe('SelectorSolarSystemObjectsComponent', () => {
     });
 
     it('trigger the showing of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = true;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(1);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
     it('trigger the hiding of the names', () => {
-      spyOn(textsVisibilityManager, 'hideTexts');
-      spyOn(textsVisibilityManager, 'showTexts');
+      spyOn(textsVisibilityManager, 'setTextsVisible');
 
       component.namesShown = false;
-      expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
-      expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(0);
+      expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
     });
 
   });
@@ -66,20 +62,20 @@ describe('SelectorSolarSystemObjectsComponent', () => {
     });
 
     it('trigger the showing of the paths', () => {
-      spyOn(pathsVisibilityManager, 'showPaths');
+      spyOn(pathsVisibilityManager, 'setPathsVisible');
 
       component.pathsShown = true;
-      expect(pathsVisibilityManager.showPaths).toHaveBeenCalledTimes(1);
-      expect(pathsVisibilityManager.showPaths).toHaveBeenCalledWith(true);
+      expect(pathsVisibilityManager.setPathsVisible).toHaveBeenCalledTimes(1);
+      expect(pathsVisibilityManager.setPathsVisible).toHaveBeenCalledWith(true);
     });
 
 
     it('trigger the hiding of the paths', () => {
-      spyOn(pathsVisibilityManager, 'showPaths');
+      spyOn(pathsVisibilityManager, 'setPathsVisible');
 
       component.pathsShown = false;
-      expect(pathsVisibilityManager.showPaths).toHaveBeenCalledTimes(1);
-      expect(pathsVisibilityManager.showPaths).toHaveBeenCalledWith(false);
+      expect(pathsVisibilityManager.setPathsVisible).toHaveBeenCalledTimes(1);
+      expect(pathsVisibilityManager.setPathsVisible).toHaveBeenCalledWith(false);
     });
 
   });

--- a/src/app/modules/layer-solar-system/components/selector-solar-system-objects/selector-solar-system-objects.component.ts
+++ b/src/app/modules/layer-solar-system/components/selector-solar-system-objects/selector-solar-system-objects.component.ts
@@ -1,7 +1,7 @@
+import { Component } from '@angular/core';
 import { UiControlsWithNames } from '#core/components/ui-controls-with-names';
 import { TextsVisibilityManagerService } from '#core/services/visibility/texts-visibility-manager.service';
 import { PathsVisibilityManagerService } from '#layer-solar-system/services/visibility/paths-visibility-manager.service';
-import { Component } from '@angular/core';
 
 
 /**
@@ -30,7 +30,7 @@ export class SelectorSolarSystemObjectsComponent extends UiControlsWithNames {
 
   public set pathsShown(show: boolean) {
     this._pathsShown = show;
-    this._pathsVisibilityManager.showPaths(this._pathsShown);
+    this._pathsVisibilityManager.setPathsVisible(this._pathsShown);
   }
 
 }

--- a/src/app/modules/layer-solar-system/model/solar-system.spec.ts
+++ b/src/app/modules/layer-solar-system/model/solar-system.spec.ts
@@ -229,47 +229,46 @@ describe('SolarSystem', () => {
 
   });
 
-  describe('hideTrajectories should', () => {
+  describe('setTrajectoriesVisible should', () => {
 
     it('remove all trajectories from the objects, if they were present', fakeAsync(() => {
       const layer = buildLayer();
       expect(layer.objects.length).toEqual(18);
 
-      layer.hideTrajectories();
+      layer.setTrajectoriesVisible(false);
       expect(layer.objects.length).toEqual(9);
     }));
-
-    it('have no effect if the trajectories were already removed', fakeAsync(() => {
-      const layer = buildLayer();
-      expect(layer.objects.length).toEqual(18);
-      layer.hideTrajectories();
-      expect(layer.objects.length).toEqual(9);
-
-      layer.hideTrajectories();
-      expect(layer.objects.length).toEqual(9);
-    }));
-
-  });
-
-
-  describe('showTrajectories should', () => {
 
     it('add all trajectories to the objects, if they were not present', fakeAsync(() => {
       const layer = buildLayer();
       expect(layer.objects.length).toEqual(18);
-      layer.hideTrajectories();
+      layer.setTrajectoriesVisible(false);
       expect(layer.objects.length).toEqual(9);
 
-      layer.showTrajectories();
+      layer.setTrajectoriesVisible(true);
       expect(layer.objects.length).toEqual(18);
     }));
 
-    it('have no effect if the trajectories were already shown', fakeAsync(() => {
-      const layer = buildLayer();
-      expect(layer.objects.length).toEqual(18);
-      layer.showTrajectories();
-      expect(layer.objects.length).toEqual(18);;
-    }));
+    describe('have no effect', () => {
+
+      it('if the trajectories were already removed', fakeAsync(() => {
+        const layer = buildLayer();
+        expect(layer.objects.length).toEqual(18);
+        layer.setTrajectoriesVisible(false);
+        expect(layer.objects.length).toEqual(9);
+
+        layer.setTrajectoriesVisible(false);
+        expect(layer.objects.length).toEqual(9);
+      }));
+
+      it('if the trajectories were already shown', fakeAsync(() => {
+        const layer = buildLayer();
+        expect(layer.objects.length).toEqual(18);
+        layer.setTrajectoriesVisible(true);
+        expect(layer.objects.length).toEqual(18);;
+      }));
+
+    });
 
   });
 

--- a/src/app/modules/layer-solar-system/model/solar-system.ts
+++ b/src/app/modules/layer-solar-system/model/solar-system.ts
@@ -92,27 +92,34 @@ export class SolarSystem extends RenderableLayer {
     this.applyTextStyle(theme.solarSystem.names);
   }
 
-  // TODO use a single showTrajectories(boolean) method
-  public hideTrajectories(): void {
+  /**
+   * Shows or hides the apparent trajectories of the objects.
+   *
+   * @param visible true to show, false to hide.
+   */
+  public setTrajectoriesVisible(visible: boolean): void {
     this._trajectories.forEach(
       (trajectory: Object3D) => {
         const index = this.getTrajectoryIndex(trajectory);
-        if (index > -1) {
-          this._objects.splice(index, 1);
+        if (visible) {
+          this.showTrajectory(index, trajectory);
+        } else {
+          this.hideTrajectory(index);
         }
       }
     );
   }
 
-  public showTrajectories(): void {
-    this._trajectories.forEach(
-      (trajectory: Object3D) => {
-        const index = this.getTrajectoryIndex(trajectory);
-        if (index === -1) {
-          this._objects.push(trajectory);
-        }
-      }
-    );
+  private hideTrajectory(index: number): void {
+    if (index > -1) {
+      this._objects.splice(index, 1);
+    }
+  }
+
+  private showTrajectory(index: number, trajectory: Object3D): void {
+    if (index === -1) {
+      this._objects.push(trajectory);
+    }
   }
 
   private applyThemeOnTrajectories(theme: Theme): void {

--- a/src/app/modules/layer-solar-system/services/factories/solar-system-layer-factory.service.ts
+++ b/src/app/modules/layer-solar-system/services/factories/solar-system-layer-factory.service.ts
@@ -80,7 +80,7 @@ export class SolarSystemLayerFactoryService implements LayerFactory {
       .then(
         (_: any) => {
           this._searchService.registerSearchables(renderable.searchables);
-          this._visibilityManager.showLayer(this._layerCode);
+          this._visibilityManager.setVisible(this._layerCode, true);
         }
       );
     return renderable;

--- a/src/app/modules/layer-solar-system/services/visibility/paths-visibility-manager.service.spec.ts
+++ b/src/app/modules/layer-solar-system/services/visibility/paths-visibility-manager.service.spec.ts
@@ -36,47 +36,37 @@ describe('PathsVisibilityManagerService', () => {
     const provider = TestBed.inject(SolarSystemProvidersService);
     const layer = provider.getRenderableLayer(model);
     layerService.registerLayer(layer);
-    layersManager.showLayer(solarSystem);
+    layersManager.setVisible(solarSystem, true);
     return layer;
   };
 
   describe('showPaths should', () => {
 
     it('have no effect if the layer does not exist', () => {
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
+      spyOn(layersManager, 'setVisible');
 
-      manager.showPaths(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(0);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(0);
+      manager.setPathsVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(0);
     });
 
     it('if the arg is true, trigger the showing of the solar system layer and trajectories', () => {
       const layer = loadSolarSystemLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'hideTrajectories');
-      spyOn(layer, 'showTrajectories');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setTrajectoriesVisible');
 
-      manager.showPaths(true);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showTrajectories).toHaveBeenCalledTimes(1);
-      expect(layer.hideTrajectories).toHaveBeenCalledTimes(0);
+      manager.setPathsVisible(true);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setTrajectoriesVisible).toHaveBeenCalledTimes(1);
     });
 
     it('if the arg is false, trigger the hiding of the solar system layer and trajectories', () => {
       const layer = loadSolarSystemLayer();
-      spyOn(layersManager, 'hideLayer');
-      spyOn(layersManager, 'showLayer');
-      spyOn(layer, 'hideTrajectories');
-      spyOn(layer, 'showTrajectories');
+      spyOn(layersManager, 'setVisible');
+      spyOn(layer, 'setTrajectoriesVisible');
 
-      manager.showPaths(false);
-      expect(layersManager.showLayer).toHaveBeenCalledTimes(1);
-      expect(layersManager.hideLayer).toHaveBeenCalledTimes(1);
-      expect(layer.showTrajectories).toHaveBeenCalledTimes(0);
-      expect(layer.hideTrajectories).toHaveBeenCalledTimes(1);
+      manager.setPathsVisible(false);
+      expect(layersManager.setVisible).toHaveBeenCalledTimes(2);
+      expect(layer.setTrajectoriesVisible).toHaveBeenCalledTimes(1);
     });
 
   });

--- a/src/app/modules/layer-solar-system/services/visibility/paths-visibility-manager.service.ts
+++ b/src/app/modules/layer-solar-system/services/visibility/paths-visibility-manager.service.ts
@@ -19,18 +19,14 @@ export class PathsVisibilityManagerService {
     this._layerCode = SolarSystem.CODE;
   }
 
-  public showPaths(show: boolean): void {
+  public setPathsVisible(visible: boolean): void {
     const layer = this.getSolarSystemLayer();
     if (!layer) {
       return;
     }
-    this._layersVisibilityManager.hideLayer(this._layerCode);
-    if (show) {
-      layer.showTrajectories();
-    } else {
-      layer.hideTrajectories();
-    }
-    this._layersVisibilityManager.showLayer(this._layerCode);
+    this._layersVisibilityManager.setVisible(this._layerCode, false);
+    layer.setTrajectoriesVisible(visible);
+    this._layersVisibilityManager.setVisible(this._layerCode, true);
   }
 
   private getSolarSystemLayer(): SolarSystem {

--- a/src/app/modules/layer-stars/components/selector-star-names/selector-star-names.component.spec.ts
+++ b/src/app/modules/layer-stars/components/selector-star-names/selector-star-names.component.spec.ts
@@ -54,55 +54,49 @@ describe('SelectorStarNamesComponent', () => {
       describe('have no effect', () => {
 
         it('if the value is negative', () => {
-          spyOn(textsVisibilityManager, 'hideTexts');
+          spyOn(textsVisibilityManager, 'setTextsVisible');
           component.shownNames = -1;
           expect(component.shownNames).toEqual(1);
-          expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
+          expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(0);
         });
 
         it('if the value is greater than the number of possible choices', () => {
-          spyOn(textsVisibilityManager, 'hideTexts');
+          spyOn(textsVisibilityManager, 'setTextsVisible');
           component.shownNames = 3;
           expect(component.shownNames).toEqual(1);
-          expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
+          expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(0);
         });
 
         it('if the choice is the same than before', () => {
-          spyOn(textsVisibilityManager, 'hideTexts');
+          spyOn(textsVisibilityManager, 'setTextsVisible');
           component.shownNames = 1;
           expect(component.shownNames).toEqual(1);
-          expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(0);
+          expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(0);
         });
 
       });
 
       it('hide the names if the choice is "None"', () => {
-        spyOn(textsVisibilityManager, 'hideTexts');
-        spyOn(textsVisibilityManager, 'showTexts');
+        spyOn(textsVisibilityManager, 'setTextsVisible');
         component.shownNames = 0;
-        expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
-        expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(0);
+        expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(1);
       });
 
       it('trigger the showing of the standard names', () => {
-        spyOn(textsVisibilityManager, 'hideTexts');
+        spyOn(textsVisibilityManager, 'setTextsVisible');
         spyOn(starsVisibilityManager, 'showStarsProperNames');
-        spyOn(textsVisibilityManager, 'showTexts');
         component.shownNames = 2;
-        expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
+        expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(2);
         expect(starsVisibilityManager.showStarsProperNames).toHaveBeenCalledWith(false);
-        expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(1);
       });
 
       it('trigger the showing of the proper names', () => {
         component.shownNames = 2;
-        spyOn(textsVisibilityManager, 'hideTexts');
+        spyOn(textsVisibilityManager, 'setTextsVisible');
         spyOn(starsVisibilityManager, 'showStarsProperNames');
-        spyOn(textsVisibilityManager, 'showTexts');
         component.shownNames = 1;
-        expect(textsVisibilityManager.hideTexts).toHaveBeenCalledTimes(1);
+        expect(textsVisibilityManager.setTextsVisible).toHaveBeenCalledTimes(2);
         expect(starsVisibilityManager.showStarsProperNames).toHaveBeenCalledWith(true);
-        expect(textsVisibilityManager.showTexts).toHaveBeenCalledTimes(1);
       });
 
     });

--- a/src/app/modules/layer-stars/components/selector-star-names/selector-star-names.component.ts
+++ b/src/app/modules/layer-stars/components/selector-star-names/selector-star-names.component.ts
@@ -48,11 +48,11 @@ export class SelectorStarNamesComponent {
   }
 
   private updateShownNames(): void {
-    this._textsVisibilityManager.hideTexts(this._layerCode);
+    this._textsVisibilityManager.setTextsVisible(this._layerCode, false);
     if (this._shownNames > 0) {
       const showProperNames = this._shownNames === 1;
       this._starsVisibilityManager.showStarsProperNames(showProperNames);
-      this._textsVisibilityManager.showTexts(this._layerCode);
+      this._textsVisibilityManager.setTextsVisible(this._layerCode, true);
     }
   }
 

--- a/src/app/modules/layer-stars/services/visibility/stars-visibility-manager.service.spec.ts
+++ b/src/app/modules/layer-stars/services/visibility/stars-visibility-manager.service.spec.ts
@@ -51,7 +51,7 @@ describe('StarsVisibilityManagerService', () => {
         const layer = provider.getRenderableLayer(model);
         layerService.registerLayer(layer);
       });
-    layersManager.showLayer(stars);
+    layersManager.setVisible(stars, true);
   };
 
   const assertLayersShown = (expectedShown: Array<string>): void => {

--- a/src/app/modules/layer-stars/services/visibility/stars-visibility-manager.service.ts
+++ b/src/app/modules/layer-stars/services/visibility/stars-visibility-manager.service.ts
@@ -29,11 +29,8 @@ export class StarsVisibilityManagerService {
   public showStarLayersDownToMagnitude(magnitude: number): void {
     this.getAllStarsLayers().forEach(
       (layer: Stars) => {
-        if (magnitude < layer.magnitudeClass) {
-          this._layersVisibilityManager.hideLayer(layer.code);
-        } else {
-          this._layersVisibilityManager.showLayer(layer.code);
-        }
+        const visible = !(magnitude < layer.magnitudeClass);
+        this._layersVisibilityManager.setVisible(layer.code, visible);
       }
     );
   }
@@ -44,9 +41,9 @@ export class StarsVisibilityManagerService {
    * @param show true to show the proper names, false for the standard names.
    */
   public showStarsProperNames(show: boolean): void {
-    this._textsVisibilityManager.hideTexts(this._layerCode);
+    this._textsVisibilityManager.setTextsVisible(this._layerCode, false);
     this.toggleNamesType(this.starsLayer, show);
-    this._textsVisibilityManager.showTexts(this._layerCode);
+    this._textsVisibilityManager.setTextsVisible(this._layerCode, true);
   }
 
   private get starsLayer(): Stars {


### PR DESCRIPTION
Closes #24.

* Aligned the API of all entities to use `set*Visible(boolean)` instead of show/hide methods.

* Reviewed the scope of all the services; set the core services to `providedIn: root`.